### PR TITLE
adjusted loop for authors

### DIFF
--- a/zotero-translator-tana.js
+++ b/zotero-translator-tana.js
@@ -20,8 +20,13 @@
   
       // author
       Zotero.write('  - Authored by:: ');
+      // write first author to field
+      Zotero.write('[[' + (item.creators[0].firstName||'') + ' ' + (item.creators[0].lastName||'') + ']] \n');
+      // remove first author from list
+      item.creators.shift()
+      // write remaining authors as indented nodes
       for (author in item.creators){
-        Zotero.write('[[' + (item.creators[author].firstName||'') + ' ' + (item.creators[author].lastName||'') + ']] ');
+        Zotero.write('    - [[' + (item.creators[author].firstName||'') + ' ' + (item.creators[author].lastName||'') + ']]\n');
       }
       Zotero.write('\n');
    


### PR DESCRIPTION
The Zotero integration currently adds authors as inline references. This means they don't show up as matching the 'author' field in queries.

Current formatting:
<img width="803" alt="CleanShot 2022-09-21 at 16 03 23@2x" src="https://user-images.githubusercontent.com/5599295/191540312-1e2c9973-a17c-4a0a-b074-c3eb236ff41b.png">

---

This change adds each author as its own node within the 'author' field (desired output):
<img width="763" alt="CleanShot 2022-09-21 at 16 04 07@2x" src="https://user-images.githubusercontent.com/5599295/191540432-2d1dc06e-9909-45b7-8ea9-5a20d8c748d4.png">

---

⚠️ There's still one remaining bug I can't figure out. The first node still renders as an inline reference:
![CleanShot 2022-09-21 at 16 01 37@2x](https://user-images.githubusercontent.com/5599295/191540049-45115845-af9d-409e-8019-42415d745669.png)

Would love help figuring out how to make that first reference direct, rather than inline
